### PR TITLE
Adzerk and AdRoll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # engineering-blogs
+* Adzerk http://adzerk.com/tech/
+* AdRoll http://tech.adroll.com/blog/
 * Airbnb-http://nerds.airbnb.com/
 * AirPair-https://www.airpair.com/posts
 * Artsy-http://artsy.github.io/


### PR DESCRIPTION
Added a couple to the top of the list as an example.
I already have a list here http://griffio.github.io/engineering-tech-blogs/.
data - https://github.com/griffio/griffio.github.io/blob/master/_data/techblogs.csv

Its true they are used as marketing/recruitment blogs too but some are great resources.