### PR TITLE
Add trivago techblog

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 * Strava http://engineering.strava.com/
 * Takipi http://blog.takipi.com/
 * Trello https://trello.engineering/
+* Trivago http://tech.trivago.com/
 * Tumblr http://engineering.tumblr.com/
 * Twitter https://blog.twitter.com/engineering
 * Twilio https://www.twilio.com/engineering/


### PR DESCRIPTION
trivago (http://trivago.com) is the world biggest hotel comparison website.
The engineering department runs a techblog as well: http://tech.trivago.com/