### PR TITLE
Aphyr - removed from Companies and moved to Individuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 * AdRoll http://tech.adroll.com/blog/
 * Airbnb http://nerds.airbnb.com/
 * AirPair https://www.airpair.com/posts
-* Aphyr https://aphyr.com/
 * Artsy http://artsy.github.io/
 * Asana https://eng.asana.com/
 * Azavea http://www.azavea.com/blogs/labs/
@@ -144,6 +143,7 @@
 * Jon Skeet http://codeblog.jonskeet.uk/
 * Jonathan Dekhtiar http://rss.jonathandekhtiar.eu/
 * Justin Weiss http://www.justinweiss.com/blog/
+* Kyle Kingsbury https://aphyr.com/
 * Marco Pivetta http://ocramius.github.io/
 * Martin Fowler http://martinfowler.com/
 * Matt Cutts https://www.mattcutts.com/blog/


### PR DESCRIPTION
Aphyr is the personal blog of Kyle Kingsbury.
Should be moved to Individuals from Companies.