### PR TITLE
Adding Sift Science - eng only

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 * Shape Security http://engineering.shapesecurity.com/
 * Sharethrough https://engineering.sharethrough.com/blog
 * Shopify http://www.shopify.com/technology
+* Sift Science http://blog.siftscience.com/?category=Engineering
 * Simple https://www.simple.com/engineering
 * Slideshare http://engineering.slideshare.net/
 * Songkick http://devblog.songkick.com/


### PR DESCRIPTION
Updated to show engineering only blog posts ( a number of which have been very well received on sites such as HackerNews, e.g. : https://news.ycombinator.com/item?id=9515392 ) . 