### PR TITLE
Add Zendesk to list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 * Yahoo http://yahooeng.tumblr.com/
 * Yammer https://eng.yammer.com/blog/
 * Yelp http://engineeringblog.yelp.com/
+* Zendesk https://developer.zendesk.com/blog
 * Zenpayroll http://engineering.zenpayroll.com/
 * Zesty http://engineering.zesty.com/
 * Zillow https://engineering.zillow.com/


### PR DESCRIPTION
The Zengineering blog was not on the list, so this pull request adds it.