### PR TITLE
Adding Schibsted Tech Polska Blog - http://www.schibsted.pl/blog/

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 * Rightscale http://eng.rightscale.com/
 * RisingStack http://blog.risingstack.com/
 * Salesforce https://developer.salesforce.com/blogs/engineering/
+* Schibsted Tech Polska http://www.schibsted.pl/blog/
 * Shape Security http://engineering.shapesecurity.com/
 * Sharethrough https://engineering.sharethrough.com/blog
 * Shopify http://www.shopify.com/technology


### PR DESCRIPTION
Added Schibsted Tech Polska blog - http://www.schibsted.pl/blog/