### PR TITLE
Adding dereuromark.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 * Codrops http://tympanus.net/codrops/
 * Daily JS http://dailyjs.com/
 * David Walsh http://davidwalsh.name/
+* Dereuromark http://www.dereuromark.de/
 * Gleb Bahmutov http://glebbahmutov.com/blog/
 * High Scalability http://highscalability.com/blog/
 * Ian Miell http://zwischenzugs.wordpress.com/


### PR DESCRIPTION
Adding `Dereuromark http://www.dereuromark.de/`, a blog mainly about (Cake)PHP software developing and web software engineering.