### PR TITLE
Add Moove-it's tech blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 * Monsanto http://engineering.monsanto.com/
 * Mozilla Automation Team http://planet.mozilla.org/ateam/
 * Mozilla Release Engineering http://planet.mozilla.org/releng/
+* Moove-it http://blog.moove-it.com/
 * Netflix http://techblog.netflix.com/
 * New York Times http://open.blogs.nytimes.com
 * Nextdoor https://engblog.nextdoor.com/


### PR DESCRIPTION
This commits adds Moove-it's blog to the list.