### PR TITLE
Add Adam Leventhal's blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@
 
 **Individuals/Group Contributors**
 * A List Apart http://alistapart.com/
+* Adam Leventhal http://dtrace.org/blogs/ahl/
 * Antirez http://antirez.com/latest/0
 * Bad Concurrency http://bad-concurrency.blogspot.com/
 * Bill the Lizard http://www.billthelizard.com/


### PR DESCRIPTION
Add Adam Leventhal's blog: [http://dtrace.org/blogs/ahl/](http://dtrace.org/blogs/ahl/).