### PR TITLE
Add allegro to list of engineering companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * Airbnb http://nerds.airbnb.com/
 * AirPair https://www.airpair.com/posts
 * Algolia https://blog.algolia.com/
+* Allegro http://allegrotech.io
 * Artsy http://artsy.github.io/
 * Asana https://eng.asana.com/
 * Atlassian https://developer.atlassian.com/blog/


### PR DESCRIPTION
Add Allegro.tech to list of engineering blogs (https://en.wikipedia.org/wiki/Allegro_(auction_website))