### PR TITLE
Add Gemfile for dependencies and update how get setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'builder'
+gem 'json'
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    json (1.8.3)
+    mini_portile (0.6.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  builder
+  json
+  nokogiri
+
+BUNDLED WITH
+   1.10.3

--- a/contributing.md
+++ b/contributing.md
@@ -6,4 +6,4 @@ Please ensure your pull request adheres to the following guidelines:
 - For individual blogs, as long as posts are mostly technical (Not as strict with the ratio as the company one), I am happy to add them.
 - For both companies and individuals, use the following format: `Name link` e.g. Airbnb http://nerds.airbnb.com/
 - The pull request and commit should include what you added/removed.
-- After making changes to the README, run the opml generation script (`./generate_opml.rb`) to update the opml file.
+- After making changes to the README, run `bundle install` to install the dependencies and then the opml generation script (`./generate_opml.rb`) to update the opml file.


### PR DESCRIPTION
Whilst I was making a single line contribution to this, I found I was missing gems and there was not an automated way of getting setup. To rectify this, I have added a Gemfile and notes in the contributing guidelines for users to run `bundle install` instead of needing to go through the require statements and
install them manually.

If you're not a fan of bundler or don't think this is required, feel free to ignore this pull request. :)