### PR TITLE
Added Pat Shaughnessy's blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ You can now read the latest blog entries or just subscribe to your favorite ones
 * Ole Begemann http://oleb.net/blog/
 * Oona Räisänen http://www.windytan.com/
 * Pamela Fox http://www.pamelafox.org/blogposts
+* Pat Shaughnessy http://patshaughnessy.net/
 * Paul Graham http://www.paulgraham.com/articles.html
 * Paul Irish http://www.paulirish.com/
 * Peter Lyons http://peterlyons.com/problog

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -233,6 +233,7 @@
     <outline type="rss" text="NSHipster" title="NSHipster" xmlUrl="http://nshipster.com/feed.xml" htmlUrl="http://nshipster.com/"/>
     <outline type="rss" text="Ole Begemann" title="Ole Begemann" xmlUrl="http://oleb.net/blog/atom.xml" htmlUrl="http://oleb.net/blog/"/>
     <outline type="rss" text="Oona Räisänen" title="Oona Räisänen" xmlUrl="http://www.windytan.com/feeds/posts/default" htmlUrl="http://www.windytan.com/"/>
+    <outline type="rss" text="Pat Shaughnessy" title="Pat Shaughnessy" xmlUrl="http://feeds2.feedburner.com/patshaughnessy" htmlUrl="http://patshaughnessy.net/"/>
     <outline type="rss" text="Paul Irish" title="Paul Irish" xmlUrl="http://feeds.feedburner.com/paul-irish" htmlUrl="http://www.paulirish.com/"/>
     <outline type="rss" text="Peter Lyons" title="Peter Lyons" xmlUrl="http://peterlyons.com/problog/feed" htmlUrl="http://peterlyons.com/problog"/>
     <outline type="rss" text="Peter Norvig" title="Peter Norvig" xmlUrl="http://www.norvig.com/rss-feed.xml" htmlUrl="http://norvig.com/"/>


### PR DESCRIPTION
Pat Shaughnessy is a prominent Rubyist. He usually [blogs](http://patshaughnessy.net) about Ruby/Rails internals. he has also written a book - [Ruby under microscope](http://patshaughnessy.net/ruby-under-a-microscope). I suggest adding his blog to the list. 