### PR TITLE
Changed title back to nickname

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ You can now read the latest blog entries or just subscribe to your favorite ones
 * Kyle Kingsbury https://aphyr.com/
 * Lambda the Ultimate http://lambda-the-ultimate.org/
 * Lea Verou http://lea.verou.me/
-* Leonard Lamprecht http://leo.github.io
+* Leo http://leo.github.io
 * Lerner Consulting Blog http://blog.lerner.co.il/
 * Life Plus Linux http://lifepluslinux.blogspot.in/
 * Marc Plano-Lesay http://enoent.fr


### PR DESCRIPTION
Thanks for the effort, @duckspeaker - but the official name of my blog is "Leo" and not "Leonard Lamprecht".

I know this might be a bit confusing (particularly because I didn't change the logo text yet), but there are some good reasons I didn't name it after my full name, primarily because it's just too hard to pronounce.

I already changed my domain and the `<title>` tag to the new name and will also make sure the logo fits it soon. Sorry for the confusion! :)