### PR TITLE
add stackexchange blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ You can now read the latest blog entries or just subscribe to your favorite ones
 * Spotify https://labs.spotify.com/
 * Square https://corner.squareup.com/
 * SRC:CLR https://blog.srcclr.com/
+* Stackexchange http://blog.stackexchange.com/engineering
 * Stormpath https://stormpath.com/blog
 * Strava http://engineering.strava.com/
 * Stride NYC http://www.stridenyc.com/blog/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -180,6 +180,7 @@
       <outline type="rss" text="Spotify" title="Spotify" xmlUrl="https://labs.spotify.com/feed/" htmlUrl="https://labs.spotify.com/"/>
       <outline type="rss" text="Square" title="Square" xmlUrl="http://feeds.feedburner.com/corner-squareup-com" htmlUrl="https://corner.squareup.com/"/>
       <outline type="rss" text="SRC:CLR" title="SRC:CLR" xmlUrl="https://blog.srcclr.com/atom.xml" htmlUrl="https://blog.srcclr.com/"/>
+      <outline type="rss" text="Stackexchange" title="Stackexchange" xmlUrl="http://blog.stackexchange.com/feed/" htmlUrl="http://blog.stackexchange.com/engineering"/>
       <outline type="rss" text="Stormpath" title="Stormpath" xmlUrl="https://stormpath.com/atom.xml" htmlUrl="https://stormpath.com/blog"/>
       <outline type="rss" text="Strava" title="Strava" xmlUrl="http://engineering.strava.com/feed/atom/" htmlUrl="http://engineering.strava.com/"/>
       <outline type="rss" text="Stride NYC" title="Stride NYC" xmlUrl="http://www.stridenyc.com/blog?format=RSS" htmlUrl="http://www.stridenyc.com/blog/"/>


### PR DESCRIPTION
As tittled.

I add Stack Exchange company blog. The link of this blog points out to http://blog.stackexchange.com/engineering. But, the feed points out to http://blog.stackexchange.com/feed/ (all new content of the blog).