### PR TITLE
Adding technical blog of Future Processing company

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ You can now read the latest blog entries or just subscribe to your favorite ones
 * Flipkart http://tech-blog.flipkart.net/
 * Foursquare http://engineering.foursquare.com/
 * Funding Circle https://engineering.fundingcircle.com/
+* Future Processing http://www.future-processing.pl/technical-blog/
 * Galois https://galois.com/blog/
 * GameChanger http://tech.gc.com/
 * GitHub http://githubengineering.com/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -77,6 +77,7 @@
       <outline type="rss" text="Flipkart" title="Flipkart" xmlUrl="http://tech-blog.flipkart.net/feed/" htmlUrl="http://tech-blog.flipkart.net/"/>
       <outline type="rss" text="Foursquare" title="Foursquare" xmlUrl="http://engineering.foursquare.com/feed/" htmlUrl="http://engineering.foursquare.com/"/>
       <outline type="rss" text="Funding Circle" title="Funding Circle" xmlUrl="https://engineering.fundingcircle.com/blog/feed.xml" htmlUrl="https://engineering.fundingcircle.com/"/>
+      <outline type="rss" text="Future Processing" title="Future Processing" xmlUrl="http://www.future-processing.pl/feed/?post_type=post" htmlUrl="http://www.future-processing.pl/technical-blog/"/>
       <outline type="rss" text="Galois" title="Galois" xmlUrl="https://galois.com/feed/" htmlUrl="https://galois.com/blog/"/>
       <outline type="rss" text="GameChanger" title="GameChanger" xmlUrl="http://tech.gc.com/atom.xml" htmlUrl="http://tech.gc.com/"/>
       <outline type="rss" text="GitHub" title="GitHub" xmlUrl="http://githubengineering.com/atom.xml" htmlUrl="http://githubengineering.com/"/>


### PR DESCRIPTION
Hi,

I'm adding [technical blog of Future Processing](http://www.future-processing.pl/technical-blog/) company to the list. Articles on the blog are technical, written in English and related to different areas of software development. I've read contribution guidelines and generated record in `engineering_blogs.opml` file.

Regards,
Piotr