### PR TITLE
Only squash commits when appropriate

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -3,8 +3,8 @@
 Please ensure your pull request adheres to the following guidelines:
 
 - For company blogs, make sure that 80% of content is technical (posts about interesting technical challenges, lessons they've learned, etc). No PR, self-promoting posts.
-- For individual blogs, as long as posts are mostly technical (Not as strict with the ratio as the company one), I am happy to add them.
+- For individual blogs, as long as posts are mostly technical (not as strict with the ratio as the company one), I am happy to add them.
 - For both companies and individuals, use the following format: `Name link` e.g. Airbnb http://nerds.airbnb.com/
-- The pull request and commit should include what you added/removed.
-- If your pull request contains two or more commits, please squash all your commits into one commit using `git rebase` for each pull request you submit.
+- The pull request and commit message should include what you added/removed.
+- Please squash related commits for each pull request you submit.
 - After making changes to the README, run `bundle install` to install the dependencies and then the opml generation script (`./generate_opml.rb`) to update the opml file.


### PR DESCRIPTION
Related to PR #305 

Enforcing single commits for every PR can have a negative impact on the project. It's more process for contributors and maintainers to follow, and increases the time it takes to get changes into the codebase. Trust that contributors will squash when appropriate.