### PR TITLE
change company name and domain of Stackexchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@
 * Spotify https://labs.spotify.com/
 * Square https://corner.squareup.com/
 * SRC:CLR https://blog.srcclr.com/
-* Stackexchange http://blog.stackexchange.com/engineering
+* Stack Overflow http://blog.stackoverflow.com/engineering/
 * Stormpath https://stormpath.com/blog
 * Strava http://engineering.strava.com/
 * Stride NYC http://www.stridenyc.com/blog/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -196,7 +196,7 @@
       <outline type="rss" text="Spotify" title="Spotify" xmlUrl="https://labs.spotify.com/feed/" htmlUrl="https://labs.spotify.com/"/>
       <outline type="rss" text="Square" title="Square" xmlUrl="http://feeds.feedburner.com/corner-squareup-com" htmlUrl="https://corner.squareup.com/"/>
       <outline type="rss" text="SRC:CLR" title="SRC:CLR" xmlUrl="https://blog.srcclr.com/atom.xml" htmlUrl="https://blog.srcclr.com/"/>
-      <outline type="rss" text="Stackexchange" title="Stackexchange" xmlUrl="http://blog.stackexchange.com/feed/" htmlUrl="http://blog.stackexchange.com/engineering"/>
+      <outline type="rss" text="Stack Overflow" title="Stack Overflow" xmlUrl="http://blog.stackoverflow.com/feed/" htmlUrl="http://blog.stackoverflow.com/engineering/"/>
       <outline type="rss" text="Stormpath" title="Stormpath" xmlUrl="https://stormpath.com/atom.xml" htmlUrl="https://stormpath.com/blog"/>
       <outline type="rss" text="Strava" title="Strava" xmlUrl="http://engineering.strava.com/feed/atom/" htmlUrl="http://engineering.strava.com/"/>
       <outline type="rss" text="Stride NYC" title="Stride NYC" xmlUrl="http://www.stridenyc.com/blog?format=RSS" htmlUrl="http://www.stridenyc.com/blog/"/>


### PR DESCRIPTION
According to [this news](http://blog.stackoverflow.com/2015/09/were-changing-our-name-back-to-stack-overflow/), __Stackexchange__ is changing its company name back to __Stack Overflow__. So, I proposed this pull request to update the company name and domain.