### PR TITLE
Adding AWS blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 * Auth0 https://auth0.com/blog/
 * Autodesk http://cloudengineering.autodesk.com/blog/
 * AWeber http://engineering.aweber.com/
+* AWS https://aws.amazon.com/blogs/aws/
 * Azavea http://www.azavea.com/blogs/labs/
 
 #### B companies


### PR DESCRIPTION
Official AWS blog is very technical, covering wide variety of engineering topics. I was surprised to not see it in this list.