### PR TITLE
Fix missing RSS blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@
 * Polyvore http://engblog.polyvore.com/
 * Postmark http://blog.postmarkapp.com/
 * Prezi https://medium.com/prezi-engineering
-* Prismatic http://blog.getprismatic.com/
 * Prolific Interactive http://blog.prolificinteractive.com/category/development/
 * PullReview http://blog.8thcolor.com/
 
@@ -480,7 +479,7 @@
 * Oona Räisänen http://www.windytan.com/
 
 #### P individuals
-* Pamela Fox http://www.pamelafox.org/blogposts
+* Pamela Fox http://blog.pamelafox.org/
 * Pat Shaughnessy http://patshaughnessy.net/
 * Paul Graham http://www.paulgraham.com/articles.html
 * Paul Irish http://www.paulirish.com/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -370,7 +370,9 @@
       <outline type="rss" text="Nate Berkopec" title="Nate Berkopec" xmlUrl="http://www.nateberkopec.com/feed.xml" htmlUrl="http://www.nateberkopec.com/"/>
       <outline type="rss" text="Ole Begemann" title="Ole Begemann" xmlUrl="http://oleb.net/blog/atom.xml" htmlUrl="http://oleb.net/blog/"/>
       <outline type="rss" text="Oona Räisänen" title="Oona Räisänen" xmlUrl="http://www.windytan.com/feeds/posts/default" htmlUrl="http://www.windytan.com/"/>
+      <outline type="rss" text="Pamela Fox" title="Pamela Fox" xmlUrl="http://blog.pamelafox.org/feeds/posts/default" htmlUrl="http://blog.pamelafox.org/"/>
       <outline type="rss" text="Pat Shaughnessy" title="Pat Shaughnessy" xmlUrl="http://feeds2.feedburner.com/patshaughnessy" htmlUrl="http://patshaughnessy.net/"/>
+      <outline type="rss" text="Paul Graham" title="Paul Graham" xmlUrl="http://www.aaronsw.com/2002/feeds/pgessays.rss" htmlUrl="http://www.paulgraham.com/articles.html"/>
       <outline type="rss" text="Paul Irish" title="Paul Irish" xmlUrl="http://feeds.feedburner.com/paul-irish" htmlUrl="http://www.paulirish.com/"/>
       <outline type="rss" text="Paul Lewis" title="Paul Lewis" xmlUrl="https://aerotwist.com/blog/feed/" htmlUrl="https://aerotwist.com/blog/"/>
       <outline type="rss" text="Peter Lyons" title="Peter Lyons" xmlUrl="http://peterlyons.com/problog/feed" htmlUrl="http://peterlyons.com/problog"/>


### PR DESCRIPTION
After generating OPML, there is a list that contains missing RSS blogs. I checked and fixed some manually. This is what I did:
* Remove Prismatic, I removed it because its link is dead.
* Change Pamela Fox's blog URL, I changed it to grab the RSS feed.
* Add Paul Graham's RSS feed manually, I saw there is one.

Please, review my pull request!
Thanks.