### PR TITLE
rename products subsections to technologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,13 +551,13 @@
 
 ### Products/Technologies
 
-#### A products
+#### A technologies
 * Atom.io http://blog.atom.io/
 
-#### G products
+#### G technologies
 * Go https://blog.golang.org/
 
-#### R products
+#### R technologies
 * Rust http://blog.rust-lang.org/
 
 ----


### PR DESCRIPTION
Keep products/technologies as the section but use the more general
technologies instead of products for the subsection labels.