### PR TITLE
Fix Xoom blog's RSS feed

### DIFF
--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -249,6 +249,7 @@
       <outline type="rss" text="Wonga Technology" title="Wonga Technology" xmlUrl="http://wongatech.github.io/feed.xml" htmlUrl="http://tech.wonga.com/"/>
       <outline type="rss" text="WyeWorks" title="WyeWorks" xmlUrl="https://wyeworks.com/blog/atom.xml" htmlUrl="https://wyeworks.com/blog/"/>
       <outline type="rss" text="XING" title="XING" xmlUrl="https://devblog.xing.com/feed/" htmlUrl="https://devblog.xing.com/"/>
+      <outline type="rss" text="Xoom" title="Xoom" xmlUrl="http://dev-blog.xoom.com/feed/" htmlUrl="http://dev-blog.xoom.com/"/>
       <outline type="rss" text="Yahoo" title="Yahoo" xmlUrl="http://yahooeng.tumblr.com/rss" htmlUrl="http://yahooeng.tumblr.com/"/>
       <outline type="rss" text="Yelp" title="Yelp" xmlUrl="http://engineeringblog.yelp.com/feed.xml" htmlUrl="http://engineeringblog.yelp.com/"/>
       <outline type="rss" text="YLD!" title="YLD!" xmlUrl="http://blog.yld.io/rss/" htmlUrl="http://blog.yld.io"/>


### PR DESCRIPTION
I just fixed Xoom blog's RSS feed manually. I have tested it by running the `generate_opml.rb" file.
The RSS feed of this blog exists. Please, review this!
Thank you.