### PR TITLE
Change Ilija Eftimov's blog address

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@
 
 #### I individuals
 * Idontgetoutmuch's Weblog https://idontgetoutmuch.wordpress.com/
-* Ilija Eftimov http://rubylogs.com/
+* Ilija Eftimov http://eftimov.net/
 * Ilya Grigorik https://www.igvita.com/
 
 #### J individuals

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -334,7 +334,7 @@
       <outline type="rss" text="High Scalability" title="High Scalability" xmlUrl="http://feeds.feedburner.com/HighScalability" htmlUrl="http://highscalability.com/"/>
       <outline type="rss" text="Huon Wilson" title="Huon Wilson" xmlUrl="http://huonw.github.io/blog/atom.xml" htmlUrl="http://huonw.github.io/"/>
       <outline type="rss" text="Idontgetoutmuch's Weblog" title="Idontgetoutmuch's Weblog" xmlUrl="https://idontgetoutmuch.wordpress.com/feed/" htmlUrl="https://idontgetoutmuch.wordpress.com/"/>
-      <outline type="rss" text="Ilija Eftimov" title="Ilija Eftimov" xmlUrl="http://rubylogs.com/rss.xml" htmlUrl="http://rubylogs.com/"/>
+      <outline type="rss" text="Ilija Eftimov" title="Ilija Eftimov" xmlUrl="http://eftimov.net/rss.xml" htmlUrl="http://eftimov.net/"/>
       <outline type="rss" text="Ilya Grigorik" title="Ilya Grigorik" xmlUrl="https://www.igvita.com/feed/" htmlUrl="https://www.igvita.com/"/>
       <outline type="rss" text="Jacopo Tarantino" title="Jacopo Tarantino" xmlUrl="https://jack.ofspades.com/rss/" htmlUrl="https://jack.ofspades.com/"/>
       <outline type="rss" text="Jake Wharton" title="Jake Wharton" xmlUrl="http://jakewharton.com/feed.xml" htmlUrl="http://jakewharton.com/blog"/>


### PR DESCRIPTION
The blog address is changed from http://rubylogs.com to http://eftimov.net.
Please, review! Thank you.