### PR TITLE
Add Nick Galbreath

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@
 * Nelson Elhage https://blog.nelhage.com/
 * Nic Raboy https://blog.nraboy.com/
 * Nick Desaulniers https://nickdesaulniers.github.io/
+* Nick Galbreath http://www.client9.com/
 * Nicolas Liochon http://blog.thislongrun.com/
 * Nikola Brežnjak http://www.nikola-breznjak.com/blog/
 * Nikolay Nemshilov http://nikolay.rocks/


### PR DESCRIPTION
Ran `generate_opml.rb` but nothing was added for this new entry, however, it generated a bunch of entries to `engineering_blogs.opml` from prior additions that may not have run the ruby script.  I manually deleted these unrelated entries since they aren't related.