### PR TITLE
add temp ignore list

### DIFF
--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -45,7 +45,6 @@
       <outline type="rss" text="Boxever" title="Boxever" xmlUrl="http://www.boxever.com/feed" htmlUrl="http://www.boxever.com/tech-blog"/>
       <outline type="rss" text="Brandwatch" title="Brandwatch" xmlUrl="http://engineering.brandwatch.com/rss/" htmlUrl="http://engineering.brandwatch.com/"/>
       <outline type="rss" text="Budacode" title="Budacode" xmlUrl="https://blog.budacode.com/feed/" htmlUrl="https://blog.budacode.com/"/>
-      <outline type="rss" text="Buzzfeed" title="Buzzfeed" xmlUrl="https://www.buzzfeed.com/galarant/python-buzzfeed" htmlUrl="https://www.buzzfeed.com/techblog"/>
       <outline type="rss" text="Canva" title="Canva" xmlUrl="https://engineering.canva.com/feed.xml" htmlUrl="https://engineering.canva.com"/>
       <outline type="rss" text="Carbon Five" title="Carbon Five" xmlUrl="http://blog.carbonfive.com/rss" htmlUrl="http://blog.carbonfive.com/"/>
       <outline type="rss" text="CenturyLink" title="CenturyLink" xmlUrl="https://www.ctl.io/developers/blog/rss" htmlUrl="https://www.ctl.io/developers/blog"/>
@@ -236,7 +235,6 @@
       <outline type="rss" text="SurveyMonkey" title="SurveyMonkey" xmlUrl="https://engineering.surveymonkey.com/feed/" htmlUrl="https://surveymonkeycodes.com"/>
       <outline type="rss" text="Takipi" title="Takipi" xmlUrl="http://blog.takipi.com/feed/" htmlUrl="http://blog.takipi.com/"/>
       <outline type="rss" text="Target" title="Target" xmlUrl="https://target.github.io/feed.xml" htmlUrl="https://target.github.io/"/>
-      <outline type="rss" text="TaskRabbit" title="TaskRabbit" xmlUrl="http://tech.taskrabbit.com/" htmlUrl="http://tech.taskrabbit.com/"/>
       <outline type="rss" text="Teamwork" title="Teamwork" xmlUrl="http://engineroom.teamwork.com/rss/" htmlUrl="http://engineroom.teamwork.com/"/>
       <outline type="rss" text="Teespring" title="Teespring" xmlUrl="http://teespring.engineering/index.xml" htmlUrl="http://teespring.engineering/"/>
       <outline type="rss" text="theScore" title="theScore" xmlUrl="http://techblog.thescore.com/feed.xml" htmlUrl="http://techblog.thescore.com/"/>

--- a/generate_opml.rb
+++ b/generate_opml.rb
@@ -16,6 +16,7 @@ contents = readme.read
 matches = contents.scan(/\* (.*) (http.*)/)
 # All blogs that do not respond
 unavailable = []
+temp_ignores = ['Buzzfeed', 'TaskRabbit', 'WyeWorks']
 
 Struct.new('Blog', :name, :web_url, :rss_url)
 blogs = []
@@ -24,6 +25,11 @@ blogs = []
 matches.each_with_index do |match, index|
   name = match[0]
   web_url = match[1]
+
+  if temp_ignores.include?(name)
+      puts "#{name}: IGNORE [TEMPORARILY]"
+      next
+  end
 
   # if rss_url already in existing opml file, use that; otherwise, do a lookup
   rss_url = nil


### PR DESCRIPTION
Sometimes the generate opml script is going to repeatedly pick things up
we want it to ignore. Create a temp ignore list to avoid this.