### PR TITLE
Adds WalmartLabs engineering blog and rss feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@
 * VNGRS http://blog.vngrs.com/
 
 #### W companies
+* WalmartLabs https://medium.com/walmartlabs/ 
 * Warby Parker http://www.theoculists.com/
 * Wattpad http://engineering.wattpad.com/
 * Wayfair http://engineering.wayfair.com/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -262,6 +262,7 @@
       <outline type="rss" text="Vine" title="Vine" xmlUrl="http://engineering.vine.co/rss" htmlUrl="http://engineering.vine.co/"/>
       <outline type="rss" text="Vinted" title="Vinted" xmlUrl="http://engineering.vinted.com//atom.xml" htmlUrl="http://engineering.vinted.com/"/>
       <outline type="rss" text="VNGRS" title="VNGRS" xmlUrl="http://blog.vngrs.com/rss.xml" htmlUrl="http://blog.vngrs.com/"/>
+      <outline type="rss" text="WalmartLabs" title="WalmartLabs" xmlUrl="https://medium.com/feed/walmartlabs" htmlUrl="https://medium.com/walmartlabs/ "/>
       <outline type="rss" text="Warby Parker" title="Warby Parker" xmlUrl="http://www.theoculists.com/feed/" htmlUrl="http://www.theoculists.com/"/>
       <outline type="rss" text="Wattpad" title="Wattpad" xmlUrl="http://engineering.wattpad.com/rss" htmlUrl="http://engineering.wattpad.com/"/>
       <outline type="rss" text="Wayfair" title="Wayfair" xmlUrl="http://engineering.wayfair.com/feed/" htmlUrl="http://engineering.wayfair.com/"/>


### PR DESCRIPTION
The new re-imagined engineering blog from WalmartLabs on Medium with brand new content - “Real, on the ground stories from real engineers.”

https://medium.com/walmartlabs

WalmartLabs engineering has been suggested before and rejected; now it's back with "real" content.