### PR TITLE
Add Haptik Engineering blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@
 
 #### H companies
 * HackerEarth http://engineering.hackerearth.com/
+* Haptik http://haptik.ai/tech/
 * Harry's http://engineering.harrys.com/
 * Hashrocket https://hashrocket.com/blog
 * Haus https://engineering.haus.com

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -126,6 +126,7 @@
       <outline type="rss" text="Guardian" title="Guardian" xmlUrl="https://www.theguardian.com/info/developer-blog/rss" htmlUrl="https://www.theguardian.com/info/developer-blog"/>
       <outline type="rss" text="Gusto" title="Gusto" xmlUrl="http://engineering.gusto.com/rss/" htmlUrl="http://engineering.gusto.com/"/>
       <outline type="rss" text="HackerEarth" title="HackerEarth" xmlUrl="http://engineering.hackerearth.com/rss" htmlUrl="http://engineering.hackerearth.com/"/>
+      <outline type="rss" text="Haptik" title="Haptik" xmlUrl="http://haptik.ai/tech/feed/" htmlUrl="http://haptik.ai/tech/"/>
       <outline type="rss" text="Harry's" title="Harry's" xmlUrl="http://engineering.harrys.com/feed.xml" htmlUrl="http://engineering.harrys.com/"/>
       <outline type="rss" text="Hashrocket" title="Hashrocket" xmlUrl="http://feeds.feedburner.com/hashrocket-blog" htmlUrl="https://hashrocket.com/blog"/>
       <outline type="rss" text="Haus" title="Haus" xmlUrl="https://engineering.haus.com/feed" htmlUrl="https://engineering.haus.com"/>


### PR DESCRIPTION
Haptik Engineering blog features blog posts from various people who have helped to build India's first AI powered virtual assistant. The blog includes challenges and lessons that we have learned, etc.