### PR TITLE
Add Compile engineering blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 * Codeship https://blog.codeship.com/
 * Collective Idea http://collectiveidea.com/blog/
 * Commercetools https://techblog.commercetools.com/
+* Compile https://www.compile.com/blog/engineering/
 * Condé Nast https://engineering.condenast.io/
 * Confluent https://www.confluent.io/blog
 * Coolblue http://devblog.coolblue.nl/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -66,6 +66,7 @@
       <outline type="rss" text="Codeship" title="Codeship" xmlUrl="https://blog.codeship.com/feed/" htmlUrl="https://blog.codeship.com/"/>
       <outline type="rss" text="Collective Idea" title="Collective Idea" xmlUrl="http://collectiveidea.com/blog/feed/" htmlUrl="http://collectiveidea.com/blog/"/>
       <outline type="rss" text="Commercetools" title="Commercetools" xmlUrl="https://techblog.commercetools.com/feed" htmlUrl="https://techblog.commercetools.com/"/>
+      <outline type="rss" text="Compile" title="Compile" xmlUrl="https://www.compile.com/blog/engineering/rss" htmlUrl="https://www.compile.com/blog/engineering/"/>
       <outline type="rss" text="Condé Nast" title="Condé Nast" xmlUrl="https://engineering.condenast.io/rss" htmlUrl="https://engineering.condenast.io/"/>
       <outline type="rss" text="Confluent" title="Confluent" xmlUrl="https://www.confluent.io/feed/" htmlUrl="https://www.confluent.io/blog"/>
       <outline type="rss" text="Coolblue" title="Coolblue" xmlUrl="http://devblog.coolblue.nl/feed/" htmlUrl="http://devblog.coolblue.nl/"/>


### PR DESCRIPTION
Adds the Compile Engineering blog. Topics include Python, Django, Data, NLP and Open Source
