### PR TITLE
Add jOOQ Engineering blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,9 @@
 #### I technologies
 * IPFS https://ipfs.io/blog/
 
+#### J technologies
+* jOOQ https://blog.jooq.org/
+
 #### K technologies
 * Klipse http://blog.klipse.tech/
 


### PR DESCRIPTION
The jOOQ blog mostly talks about:

- What it takes to implement jOOQ (e.g. JDBC specifics)
- Java language stuff (e.g. how generics and overloading work)
- API design stuff (e.g. best practices for backwards compatibility)
- SQL stuff and tricks (e.g. how to do XY in SQL)

I think it qualifies, given that probably more than 80% is technical and less than 20% is really about jOOQ. Some popular examples:

- https://blog.jooq.org/2014/08/12/the-difference-between-row_number-rank-and-dense_rank/
- https://blog.jooq.org/2016/03/17/10-easy-steps-to-a-complete-understanding-of-sql/
- https://blog.jooq.org/2014/12/04/do-you-really-understand-sqls-group-by-and-having-clauses/
- https://blog.jooq.org/2016/04/25/10-sql-tricks-that-you-didnt-think-were-possible/
- https://blog.jooq.org/2015/02/05/top-10-easy-performance-optimisations-in-java/