### PR TITLE
Remove Linkedcare

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@
 * Laterooms http://engineering.laterooms.com/
 * LendingHome https://tech.lendinghome.com/
 * LINE https://engineering.linecorp.com/en/blog
-* Linkedcare http://blog.linkedcare.com/
 * LinkedIn https://engineering.linkedin.com/blog
 * Linode https://engineering.linode.com/
 * LiveChat https://developers.livechatinc.com/blog/


### PR DESCRIPTION
There are no records for `blog.linkedcare.com` (`dig @8.8.8.8 a blog.linkedcare.com` yields no answers), and they don't seem to have moved the blog elsewhere.