### PR TITLE
Remove Ducode.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,6 @@
 * Dragan Djuric http://dragan.rocks
 * Dragan Gaic http://www.gajotres.net/
 * Drew DeVault https://drewdevault.com/
-* Ducode.org https://ducode.org/tag/tutorial
 
 #### E individuals
 * Edan Kwan http://blog.edankwan.com/


### PR DESCRIPTION
It seems this website is down. When I try to load this website, it says unable to connect.