### PR TITLE
Remove non-existent asos techblog

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@
 * Arkency http://blog.arkency.com/
 * Artsy http://artsy.github.io/
 * Asana https://blog.asana.com/category/eng/
-* Asos http://techblog.asos.com/
 * Atlassian https://developer.atlassian.com/blog/
 * Atomic Object https://spin.atomicobject.com/
 * Auth0 https://auth0.com/blog/


### PR DESCRIPTION
The asos techblog seems to be gone, I couldn't find a new address.