### PR TITLE
Add Graphcool blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@
 * Grab http://engineering.grab.com/
 * Grafana https://grafana.com/blog/
 * Grammarly https://tech.grammarly.com/blog/index.html
+* Graphcool https://blog.graph.cool/
 * Grofers https://lambda.grofers.com/
 * Grouper http://blog.joingrouper.com/
 * Groupon https://engineering.groupon.com/


### PR DESCRIPTION
Add the engineering blog of Graphcool.

Homepage of company: [here](http://www.graph.cool/)