### PR TITLE
Add meta RSS feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,9 @@
 
 # RSS feeds
 
-You can find an opml file to import rss feeds here: [engineering_blogs.opml](./engineering_blogs.opml)
+You can find an opml file to import RSS feeds here: [engineering_blogs.opml](./engineering_blogs.opml)
+
+You can also follow an RSS feed for [_this_ project](https://github.com/kilimchoi/engineering-blogs/commits.atom) or just the [README](https://github.com/kilimchoi/engineering-blogs/commits/master/README.md.atom).
 
 # Contributing
 


### PR DESCRIPTION
Adds some links to the "meta" RSS feeds. I just subscribed to these because I want to see new additions, but not necessarily new GitHub notifications, e.g. Issues.

N.B. Relative links _probably_ work okay on `kilimchoi`'s source, but it was not working as expected on my branch. So, I left them as absolute.