### PR TITLE
Remove Deis blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@
 * DataFox http://eng.datafox.co/
 * Deezer https://deezer.io/
 * DeferPanic https://deferpanic.com/blog/
-* Deis https://deis.com/blog
 * Deliveroo https://deliveroo.engineering/
 * DigitalOcean https://www.digitalocean.com/community/tutorials
 * Discord https://blog.discordapp.com/


### PR DESCRIPTION
Deis blog is no longer available (probably since the acquisition by Azure).