### PR TITLE
Fixing Hashnode engineering links

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@
 * HackerEarth http://engineering.hackerearth.com/
 * Haptik https://haptik.ai/tech/
 * Harry's http://engineering.harrys.com/
-* Hashnode https://hashnode.blog/
+* Hashnode https://engineering.hashnode.com/
 * Hashrocket https://hashrocket.com/blog
 * Hasura https://blog.hasura.io/
 * Haus https://engineering.haus.com

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -142,7 +142,7 @@
       <outline type="rss" text="HackerEarth" title="HackerEarth" xmlUrl="http://engineering.hackerearth.com/rss" htmlUrl="http://engineering.hackerearth.com/"/>
       <outline type="rss" text="Haptik" title="Haptik" xmlUrl="https://haptik.ai/tech/feed/" htmlUrl="https://haptik.ai/tech/"/>
       <outline type="rss" text="Harry's" title="Harry's" xmlUrl="http://engineering.harrys.com/feed.xml" htmlUrl="http://engineering.harrys.com/"/>
-      <outline type="rss" text="Hashnode" title="Hashnode" xmlUrl="https://hashnode.blog/feed" htmlUrl="https://hashnode.blog/"/>
+      <outline type="rss" text="Hashnode" title="Hashnode" xmlUrl="https://engineering.hashnode.com/rss.xml" htmlUrl="https://engineering.hashnode.com/"/>
       <outline type="rss" text="Hashrocket" title="Hashrocket" xmlUrl="https://hashrocket.com/blog.rss" htmlUrl="https://hashrocket.com/blog"/>
       <outline type="rss" text="Hasura" title="Hasura" xmlUrl="https://blog.hasura.io/feed" htmlUrl="https://blog.hasura.io/"/>
       <outline type="rss" text="Haus" title="Haus" xmlUrl="https://engineering.haus.com/feed" htmlUrl="https://engineering.haus.com"/>


### PR DESCRIPTION
The old ones were leading to the general blog, while this one is exclusively maintained by the engineering team at Hashnode.