### PR TITLE
Updated Nic Raboy blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@
 #### N individuals
 * Natasha Murashev https://natashatherobot.com
 * Nelson Elhage https://blog.nelhage.com/
-* Nic Raboy https://blog.nraboy.com/
+* Nic Raboy https://www.thepolyglotdeveloper.com/blog/
 * Nick Craver https://nickcraver.com/blog/
 * Nick Desaulniers https://nickdesaulniers.github.io/
 * Nick Galbreath http://www.client9.com/


### PR DESCRIPTION
404 error on the old link: https://blog.nraboy.com/