### PR TITLE
Duplicated Docker engineering link

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@
 * DigitalOcean https://blog.digitalocean.com/tag/engineering/
 * Discord https://blog.discordapp.com/
 * Docker https://blog.docker.com/
-* Docker Engineering https://engineering.docker.com/
 * DoorDash https://blog.doordash.com/tagged/engineering
 * Doximity https://engineering.doximity.com
 * Drivy https://drivy.engineering/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -87,7 +87,6 @@
       <outline type="rss" text="DigitalOcean" title="DigitalOcean" xmlUrl="https://blog.digitalocean.com/rss/" htmlUrl="https://blog.digitalocean.com/tag/engineering/"/>
       <outline type="rss" text="Discord" title="Discord" xmlUrl="https://blog.discordapp.com/feed" htmlUrl="https://blog.discordapp.com/"/>
       <outline type="rss" text="Docker" title="Docker" xmlUrl="https://blog.docker.com/feed/" htmlUrl="https://blog.docker.com/"/>
-      <outline type="rss" text="Docker Engineering" title="Docker Engineering" xmlUrl="https://engineering.docker.com/feed/" htmlUrl="https://engineering.docker.com/"/>
       <outline type="rss" text="DoorDash" title="DoorDash" xmlUrl="https://medium.com/feed/doordash-blog/tagged/engineering" htmlUrl="https://blog.doordash.com/tagged/engineering"/>
       <outline type="rss" text="Doximity" title="Doximity" xmlUrl="https://engineering.doximity.com/feed" htmlUrl="https://engineering.doximity.com"/>
       <outline type="rss" text="Drivy" title="Drivy" xmlUrl="https://drivy.engineering/feed.xml" htmlUrl="https://drivy.engineering/"/>


### PR DESCRIPTION
Docker engineering link redirects to the same link as Docker link. It is now a duplicate link.