### PR TITLE
Add Bloomberg Tech Blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 * BlackRock http://rockthecode.io/
 * Blender https://code.blender.org/
 * Blogfoster http://engineering.blogfoster.com/
+* Bloomberg https://www.techatbloomberg.com/
 * Booking.com https://blog.booking.com/
 * Boxever http://www.boxever.com/blog/
 * Brandwatch http://engineering.brandwatch.com/


### PR DESCRIPTION
Bloomberg https://www.techatbloomberg.com/
This is dedicated tech blog by Bloomberg. The world leading financial service provider.