### PR TITLE
Feedbag not reachable if RSS feed not found by Google Feeds Api

### DIFF
--- a/generate_opml.rb
+++ b/generate_opml.rb
@@ -72,8 +72,12 @@ matches.each do |match|
     puts "#{name}: GETTING"
     rss_check_url = "http://ajax.googleapis.com/ajax/services/feed/lookup?v=1.0&q=#{web_url}"
     uri = URI.parse(rss_check_url)
-    response = JSON.parse(Net::HTTP.get(uri))
-    rss_url = response['responseData']['url'] if response['responseData'] && response['responseData'].has_key?('url')
+    begin
+        response = JSON.parse(Net::HTTP.get(uri))
+        rss_url = response['responseData']['url'] if response['responseData'] && response['responseData'].has_key?('url')
+    rescue Exception => e
+        puts "#{name}: RSS feed not found from Google Feeds Api. Using Feedbag instead"
+    end
 
     # use Feedbag as a backup to Google Feeds Api
     if rss_url.nil?


### PR DESCRIPTION
In case RSS feed of a website is not found by Google Feeds Api, an exception will be thrown and the code to generate RSS from Feedbag is not reachable.

Excerpt from my log
```
Software Engineering Daily: GETTING
Traceback (most recent call last):
	4: from generate_opml.rb:50:in `<main>'
	3: from generate_opml.rb:50:in `each'
	2: from generate_opml.rb:75:in `block in <main>'
	1: from /usr/local/Cellar/ruby/2.7.1_2/lib/ruby/2.7.0/json/common.rb:156:in `parse'
/usr/local/Cellar/ruby/2.7.1_2/lib/ruby/2.7.0/json/common.rb:156:in `parse': 783: unexpected token at '<!DOCTYPE html> (JSON::ParserError)
```