### PR TITLE
Add Datadog engineering blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@
 #### D companies
 * Data Artisans https://data-artisans.com/blog/
 * Databricks https://databricks.com/blog
+* Datadog https://www.datadoghq.com/blog/engineering/
 * DataFox http://eng.datafox.co/
 * Deezer https://deezer.io/
 * DeferPanic https://deferpanic.com/blog/


### PR DESCRIPTION
https://www.datadoghq.com/blog/engineering/