### PR TITLE
Add Jade Rubick engineering leadership blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@
 
 #### J individuals
 * Jacopo Tarantino https://jack.ofspades.com/
+* Jade Rubick https://www.rubick.com/
 * Jake Trent https://jaketrent.com
 * Jake Wharton http://jakewharton.com/blog
 * Jake Yesbeck http://jakeyesbeck.com/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -466,6 +466,7 @@
       <outline type="rss" text="Itamar Turner-Trauring" title="Itamar Turner-Trauring" xmlUrl="https://codewithoutrules.com/atom.xml" htmlUrl="https://codewithoutrules.com"/>
       <outline type="rss" text="Ivan Ursul" title="Ivan Ursul" xmlUrl="https://ivanursul.com/feed.xml" htmlUrl="https://ivanursul.com/"/>
       <outline type="rss" text="Jacopo Tarantino" title="Jacopo Tarantino" xmlUrl="https://jack.ofspades.com/rss/index.html" htmlUrl="https://jack.ofspades.com/"/>
+      <outline type="rss" text="Jade Rubick" title="Jade Rubick" xmlUrl="https://www.rubick.com/rss.xml" htmlUrl="https://www.rubick.com"/>
       <outline type="rss" text="Jake Trent" title="Jake Trent" xmlUrl="https://jaketrent.com/index.xml" htmlUrl="https://jaketrent.com"/>
       <outline type="rss" text="Jake Wharton" title="Jake Wharton" xmlUrl="http://jakewharton.com/feed.xml" htmlUrl="http://jakewharton.com/blog"/>
       <outline type="rss" text="Jake Yesbeck" title="Jake Yesbeck" xmlUrl="http://jakeyesbeck.com/atom.xml" htmlUrl="http://jakeyesbeck.com/"/>


### PR DESCRIPTION
You can see the list of posts here: https://www.rubick.com/posts/ or by tag here: https://www.rubick.com/tags/

Covers engineering leadership topics. 