### PR TITLE
Add Hanami Mastery blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@
 * Guilherme Rodrigues https://firstdoit.com/
 
 #### H individuals
+* Hanami Mastery https://hanamimastery.com
 * Hayden James https://haydenjames.io/
 * Henrik Lau Eriksson https://conductofcode.io/
 * Henrik Warne https://henrikwarne.com/


### PR DESCRIPTION
Hanami Mastery https://hanamimastery.com

100% technical blog, started by individual, slowely is transitioning to be driven by a group of passionates

A blog and screencasts about
- Ruby,
- Hanami
- related technical stuff.

Several times highlighted by the most popular ruby media (i.e https://rubyweekly.com)