### PR TITLE
Add Hanami ruby web framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,6 +757,9 @@
 #### G technologies
 * Go https://blog.golang.org/
 
+#### H technologies
+* Hanami https://hanamirb.org/
+
 #### I technologies
 * IPFS https://ipfs.io/blog/
 


### PR DESCRIPTION
Hanami https://hanamirb.org/

Hanami is a next-generation ruby application framework, allowing to create any kind of application, including Web apps.
Used by companies, like: DNSimple, AscendaLoyalty, Vodafone, and more.