### PR TITLE
Add Ruby on Rails web framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@
 * Red http://www.red-lang.org
 * RocksDB http://rocksdb.org/blog
 * Rust https://blog.rust-lang.org/
+* Ruby on Rails https://rubyonrails.org/
 
 #### S technologies
 * Sketch https://blog.sketchapp.com/


### PR DESCRIPTION
Ruby on Rails https://rubyonrails.org/

Ruby on Rails is a most popular ruby web framework, used by companies like: Github, Shopfiy, Bloomberg, Fiverr, Cookpad, and much more.