### PR TITLE
Add Taro blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@
 #### T companies
 * Takipi http://blog.takipi.com/
 * Target https://target.github.io/
+* Taro https://www.jointaro.com/blog/
 * TaskRabbit http://tech.taskrabbit.com/
 * Teamwork https://engineroom.teamwork.com/
 * Teespring http://teespring.engineering/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -271,6 +271,7 @@
       <outline type="rss" text="Swiggy" title="Swiggy" xmlUrl="https://bytes.swiggy.com/feed" htmlUrl="https://bytes.swiggy.com/"/>
       <outline type="rss" text="Takipi" title="Takipi" xmlUrl="https://blog.takipi.com/feed/" htmlUrl="http://blog.takipi.com/"/>
       <outline type="rss" text="Target" title="Target" xmlUrl="https://target.github.io/feed.xml" htmlUrl="https://target.github.io/"/>
+      <outline type="rss" text="Taro" title="Taro" xmlUrl="https://www.jointaro.com/blog/rss/" htmlUrl="https://www.jointaro.com/blog/"/>
       <outline type="rss" text="TaskRabbit" title="TaskRabbit" xmlUrl="http://tech.taskrabbit.com/feed.xml" htmlUrl="http://tech.taskrabbit.com/"/>
       <outline type="rss" text="Teamwork" title="Teamwork" xmlUrl="https://engineroom.teamwork.com/feed" htmlUrl="https://engineroom.teamwork.com/"/>
       <outline type="rss" text="Teespring" title="Teespring" xmlUrl="http://teespring.engineering/index.xml" htmlUrl="http://teespring.engineering/"/>


### PR DESCRIPTION
The Taro blog contains  posts about how to grow your software engineer career.