### PR TITLE
Removed boxever blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@
 * Blender https://code.blender.org/
 * Blogfoster http://engineering.blogfoster.com/
 * Booking.com https://blog.booking.com/
-* Boxever http://www.boxever.com/blog/
 * Brandwatch http://engineering.brandwatch.com/
 
 #### C companies

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -38,7 +38,6 @@
       <outline type="rss" text="BlackRock" title="BlackRock" xmlUrl="http://rockthecode.io/feed/" htmlUrl="http://rockthecode.io/"/>
       <outline type="rss" text="Blender" title="Blender" xmlUrl="https://code.blender.org/rss" htmlUrl="https://code.blender.org/"/>
       <outline type="rss" text="Blogfoster" title="Blogfoster" xmlUrl="http://engineering.blogfoster.com/rss/" htmlUrl="http://engineering.blogfoster.com/"/>
-      <outline type="rss" text="Boxever" title="Boxever" xmlUrl="https://www.boxever.com/feed/" htmlUrl="http://www.boxever.com/blog/"/>
       <outline type="rss" text="Brandwatch" title="Brandwatch" xmlUrl="https://engineering.brandwatch.com/rss/" htmlUrl="http://engineering.brandwatch.com/"/>
       <outline type="rss" text="Canva" title="Canva" xmlUrl="https://product.canva.com/feed.xml" htmlUrl="https://engineering.canva.com"/>
       <outline type="rss" text="Capgemini" title="Capgemini" xmlUrl="https://capgemini.github.io/feed.xml" htmlUrl="https://capgemini.github.io/"/>


### PR DESCRIPTION
For http://www.boxever.com/blog/:
"The resource you are looking for has been removed, had its name changed, or is temporarily unavailable."