### PR TITLE
Add joepweijers's blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,7 @@
 * Joe Armstrong https://joearms.github.io/
 * Joe Nelson https://begriffs.com/
 * Joel Spolsky https://www.joelonsoftware.com/
+* Joep Weijers https://joepweijers.nl/?technical-notes
 * Johannes Brodwall http://johannesbrodwall.com/
 * John Resig https://johnresig.com/category/blog/
 * John Wittenauer http://www.johnwittenauer.net/


### PR DESCRIPTION
Technical notes on mostly software engineering topics and practices. Also contains tips for public speaking.