### PR TITLE
Remove dead Chaps blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@
 * Capgemini https://capgemini.github.io/
 * CenturyLink https://www.ctl.io/developers/blog
 * Cerner http://engineering.cerner.com/
-* Chaps https://blog.chaps.io/
 * Chartbeat http://engineering.chartbeat.com/
 * Chef https://blog.chef.io
 * Clever https://engineering.clever.com/


### PR DESCRIPTION
It longer exists and isn't coming back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the entry for `Chaps` from the list of companies in the README file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->