### PR TITLE
Add JVM Weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@
 
 #### J technologies
 * jOOQ https://blog.jooq.org/
+* JVM Weekly https://www.jvm-weekly.com/
 
 #### K technologies
 * Kotlin https://blog.jetbrains.com/kotlin/

--- a/engineering_blogs.opml
+++ b/engineering_blogs.opml
@@ -417,6 +417,7 @@
       <outline type="rss" text="Go" title="Go" xmlUrl="https://blog.golang.org/blog/feed.atom" htmlUrl="https://blog.golang.org/"/>
       <outline type="rss" text="IPFS" title="IPFS" xmlUrl="https://blog.ipfs.tech/index.xml" htmlUrl="https://ipfs.io/blog/"/>
       <outline type="rss" text="jOOQ" title="jOOQ" xmlUrl="https://blog.jooq.org/feed/" htmlUrl="https://blog.jooq.org/"/>
+      <outline type="rss" text="JVM Weekly" title="JVM Weekly" xmlUrl="https://jvm-weekly.substack.com/feed" htmlUrl="https://www.jvm-weekly.com/"/>
       <outline type="rss" text="Kotlin" title="Kotlin" xmlUrl="https://blog.jetbrains.com/kotlin/feed/" htmlUrl="https://blog.jetbrains.com/kotlin/"/>
       <outline type="rss" text="Laravel" title="Laravel" xmlUrl="https://feed.laravel-news.com/" htmlUrl="https://laravel-news.com/blog/"/>
       <outline type="rss" text="Microsoft Edge" title="Microsoft Edge" xmlUrl="https://blogs.windows.com/msedgedev/wp-json/wp/v2/pages/24431" htmlUrl="https://blogs.windows.com/msedgedev/"/>


### PR DESCRIPTION
Add JVM Weekly to the J technologies section. JVM Weekly is a newsletter by Artur Skowronski covering the JVM ecosystem (Java, Kotlin, Scala, GraalVM, Quarkus). RSS: https://jvm-weekly.substack.com/feed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added JVM Weekly, a new technology resource, to the available references and feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->